### PR TITLE
build(deps): upgrade bincode 1 to 2

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -34,11 +34,22 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -458,10 +469,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -16,4 +16,4 @@ rayon = "1.10"
 walkdir = "2"
 regex = "1"
 chrono = { version = "0.4", features = ["serde"] }
-bincode = "1"
+bincode = { version = "2", features = ["serde"] }

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -23,7 +23,7 @@ impl ZettelData {
 }
 
 /// Dynamic YAML value type that can be converted to Python objects.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, bincode::Encode, bincode::Decode)]
 pub enum YamlValue {
     Null,
     Bool(bool),
@@ -31,7 +31,7 @@ pub enum YamlValue {
     Float(f64),
     String(String),
     List(Vec<YamlValue>),
-    DateTime(chrono::DateTime<chrono::FixedOffset>),
+    DateTime(#[bincode(with_serde)] chrono::DateTime<chrono::FixedOffset>),
 }
 
 impl YamlValue {


### PR DESCRIPTION
## Summary
- Upgrade `bincode` from 1 to 2 (bincode 3.0.0 is a joke/unmaintained release)
- Migrate to native `Encode`/`Decode` derives with `#[bincode(with_serde)]` for chrono `DateTime`
- Bump `CACHE_VERSION` to 2 (binary format changed)

Replaces #4.